### PR TITLE
removed target=_blank

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -216,8 +216,6 @@ const AboutPage = () => {
               <div className="about-contributor-links">
                 <a
                   href="https://github.com/1046prt"
-                  target="_blank"
-                  rel="noopener noreferrer"
                   className="about-contributor-link"
                   title="GitHub Profile"
                 >
@@ -240,8 +238,7 @@ const AboutPage = () => {
               <div className="about-contributor-links">
                 <a
                   href="https://github.com/shiven0204"
-                  target="_blank"
-                  rel="noopener noreferrer"
+                
                   className="about-contributor-link"
                   title="GitHub Profile"
                 >

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -48,19 +48,19 @@ const Footer: FC = () => {
           <div className="footer-socials">
             <a
               href="https://github.com/1046prt"
-              target="_blank"
+              
               aria-label="Github"
             >
               <Github size={20} />
             </a>
             <a
               href="https://twitter.com/1046prt"
-              target="_blank"
+              
               aria-label="Twitter"
             >
               <Twitter size={20} />
             </a>
-            <a href="/" target="_blank" aria-label="Website">
+            <a href="/" aria-label="Website">
               <Globe size={20} />
             </a>
             <a href="mailto:1046prt@gmail.com" aria-label="Email">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "worldexplorer",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "worldexplorer",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "1.2.2",


### PR DESCRIPTION
Remove target="_blank" from all links (e.g., “Browse”) so they don’t open in a new tab.